### PR TITLE
feat: Add API functions for adding, getting, and removing combos

### DIFF
--- a/src/api/addCombo.ts
+++ b/src/api/addCombo.ts
@@ -1,0 +1,11 @@
+import api from "./axiosConfig";
+import { comboType } from "./type";
+
+export const addCombo = async (combo: comboType): Promise<void> => {
+  try {
+    const response = await api.post(`/api/v1/combos`, combo);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/getCombo.ts
+++ b/src/api/getCombo.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import api from "./axiosConfig";
+import { comboType } from "./type";
+
+const useComboDetail = (id: string): comboType | undefined => {
+  const [combo, setCombo] = useState<comboType>();
+  const getCombo = async (): Promise<void> => {
+    try {
+      const response = await api.get(`/api/v1/combos/${id}`);
+      setCombo(response.data);
+    } catch (error) {
+      console.log(error);
+      return undefined;
+    }
+  };
+  useEffect(() => {
+    getCombo();
+  }, []);
+  return combo;
+};
+
+export default useComboDetail;

--- a/src/api/removeCombo.ts
+++ b/src/api/removeCombo.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from "axios";
+import api from "./axiosConfig";
+
+export const removeCombo = async (
+  comboId: string
+): Promise<AxiosResponse<any, any> | unknown> => {
+  try {
+    const res = await api.delete(`/api/v1/combos/${comboId}`);
+    return res;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/api/type.d.ts
+++ b/src/api/type.d.ts
@@ -82,6 +82,14 @@ export interface SeatRequest {
   calendarId: string;
 }
 
+export interface comboType {
+  name: String;
+  price: int;
+  description: String;
+  image: String;
+  discount: int;
+}
+
 enum SeatType {
   A = "A",
   B = "B",

--- a/src/views/admin/Dashboard.tsx
+++ b/src/views/admin/Dashboard.tsx
@@ -67,6 +67,7 @@ const Dashboard = () => {
           </div>
           <Tabs tabPosition={"left"} items={itemsTab} />
         </div>
+        <div className="dashboard-right"></div>
       </div>
     </Layout>
   );


### PR DESCRIPTION
- Added the `addCombo` function to make a POST request to `/api/v1/combos` and add a new combo.
- Added the `getCombo` function to make a GET request to `/api/v1/combos/{id}` and retrieve a specific combo.
- Added the `removeCombo` function to make a DELETE request to `/api/v1/combos/{comboId}` and remove a combo.

Refactor the `useComboDetail` hook to use the `getCombo` function and set the combo state.

Update the `type.d.ts` file to include the `comboType` interface.

Add a new `div` with the class `dashboard-right` to the `Dashboard` component in the `admin` views.

Refactor the `Dashboard.scss` file to improve tab styling and layout, fix search field width issue, and handle error response in the `addCalendar` API call.