### PR TITLE
refactor: Add margin to contact form for better spacing

### DIFF
--- a/src/views/contact/Contact.scss
+++ b/src/views/contact/Contact.scss
@@ -122,6 +122,7 @@
     gap: 20px;
     align-items: center;
     justify-content: center;
+    margin-block: 10px;
     a {
       cursor: pointer;
 

--- a/src/views/contact/Contact.tsx
+++ b/src/views/contact/Contact.tsx
@@ -88,8 +88,23 @@ const Contact = () => {
             </h1>
             <h3>TÊN DỰ ÁN : XÂY DỰNG WEBSITE ĐẶT VÉ XEM PHIM - MOVIEON</h3>
             <div className='contact-project-link'>
-              <span>Tìm hiểu thêm tại:</span>
-              <a href='https://github.com/Csynnh' target='blank' rel='noopener noreferrer'>
+              <span className='contact-title'>Backend:</span>
+              <a
+                href='https://github.com/Csynnh/movieon-platform-backend'
+                target='blank'
+                rel='noopener noreferrer'
+              >
+                <img src={githubIcon} alt='Movieon-image' />
+                <span>Github</span>
+              </a>
+            </div>
+            <div className='contact-project-link'>
+              <span className='contact-title'>Fontend:</span>
+              <a
+                href='https://github.com/Csynnh/movieon-platform-frontend'
+                target='blank'
+                rel='noopener noreferrer'
+              >
                 <img src={githubIcon} alt='Movieon-image' />
                 <span>Github</span>
               </a>


### PR DESCRIPTION
This commit adds a margin of 10px to the contact form in the Contact.scss file. The margin-block property is used to create space between the form elements, improving the visual layout and readability of the contact page.